### PR TITLE
Provide better slave information for build wrapper

### DIFF
--- a/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
+++ b/src/main/java/jenkins/plugins/logstash/LogstashWriter.java
@@ -53,7 +53,7 @@ public class LogstashWriter {
 
   final OutputStream errorStream;
   final AbstractBuild<?, ?> build;
-  final BuildData buildData;
+  BuildData buildData;
   final String jenkinsUrl;
   final LogstashIndexerDao dao;
   private boolean connectionBroken;
@@ -81,6 +81,9 @@ public class LogstashWriter {
    *          Message, not null
    */
   public void write(String line) {
+    if (line.contains("Building remotely")) {
+      this.buildData = getBuildData();
+    }
     if (!isConnectionBroken() && StringUtils.isNotEmpty(line)) {
       this.write(Arrays.asList(line));
     }


### PR DESCRIPTION
Populates `buildHost` field with the actual build host, instead of `master`.

Slave is not known at the start of the build. If we retry getting BuildData when we see "Building remotely" string in the logs, slave data and many more interesting env vars will be available.
